### PR TITLE
Better check for nvm availablity.

### DIFF
--- a/scripts/nodejs-change-version.sh
+++ b/scripts/nodejs-change-version.sh
@@ -2,22 +2,24 @@
 # if you need more help installing node - https://gist.github.com/isaacs/579814
 #
 
-if [ "$(uname)" == "Darwin" ]; then
-	echo "You're using macOS."
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	echo "You're using Linux."
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
-    echo "Please Update Node.js from https://nodejs.org and install it."
-    exit 1
-fi
+#if [ "$(uname)" == "Darwin" ]; then
+#	echo "You're using macOS."
+#elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+#	echo "You're using Linux."
+#elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+#fi
+
+[ $(node -p process.platform) == "win32" ] && echo "Please Update Node.js from https://nodejs.org and install it." && exit 1
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
 
-# if ! [ -x "$(command -v nvm)" ]; then
-#   echo "Please install nvm and try again."
-#   exit 1
-# fi
+if [ $(type -t nvm) == "function" ]; then
+  echo "Successfully loaded nvm."
+else
+  echo "Please install nvm and try again."
+  exit 1
+fi
 
 echo "Please enter a version of Node.js"
 read input_variable

--- a/scripts/nodejs-change-version.sh
+++ b/scripts/nodejs-change-version.sh
@@ -2,13 +2,6 @@
 # if you need more help installing node - https://gist.github.com/isaacs/579814
 #
 
-#if [ "$(uname)" == "Darwin" ]; then
-#	echo "You're using macOS."
-#elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-#	echo "You're using Linux."
-#elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
-#fi
-
 [ $(node -p process.platform) == "win32" ] && echo "Please Update Node.js from https://nodejs.org and install it." && exit 1
 
 export NVM_DIR="$HOME/.nvm"

--- a/scripts/nodejs-install.sh
+++ b/scripts/nodejs-install.sh
@@ -36,7 +36,7 @@ fi
 install_node () {
 	export NVM_DIR="$HOME/.nvm"
 	[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
-	echo "nvm is installed. Installing Node.js v6.9.2."  
+	echo "nvm is installed. Installing Node.js v6.9.2."
 	nvm install 6.9.2
 }
 


### PR DESCRIPTION
Turns out that we should use a different way to check if `nvm` exists, since it's a function, not a command. 