### PR TITLE
Fix meanstackjs loading problem due to too old node-sass package use …

### DIFF
--- a/tools/livereload/package.json
+++ b/tools/livereload/package.json
@@ -12,7 +12,7 @@
     "less": "2.7.1",
     "livereload": "0.6.0",
     "lodash": "4.17.2",
-    "node-sass": "4.1.1"
+    "node-sass": "^4.5.0"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
…with node v8.9.3

Exception occurred in starting with node v8.9.3:
"uncaughtException: Node Sass does not yet support your current environment: Windows 64-bit with Unsupported"

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
